### PR TITLE
feature/create pr auto

### DIFF
--- a/.github/workflows/create_pr_staging.yml
+++ b/.github/workflows/create_pr_staging.yml
@@ -26,7 +26,7 @@ jobs:
           echo "::set-output name=count::$(gh pr list -S ${pr_title}' in:title' -B $base_branch | wc -l)"
           echo "::set-output name=pr_title::$pr_title"
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN_FOR_GH }}
+          GH_TOKEN: ${{ secrets.TOKEN_FOR_GH }}
 
       - name: Create release pr
         if: ${{ steps.check_pr.outputs.count == 0 }}


### PR DESCRIPTION
- feat: PRの自動作成のワークフローを実装
- 構文エラーの修正
- インデント修正
- bodyには何も記載しないので設定を削除
- スペースを追加
- fix
- 環境変数展開できるようにした
- release/*ブランチへのマージをトリガーで動かす
- 構文fix
- gh createコマンドに必要な引数を設定
- 自動生成PRのテンプレートを作成
- 実装かえた
- /*にした
- 実装もどした
- refみる
- falseの条件も追加した
- test
- ブランチ名を直接指定
- ブランチ指定でpull requestがmergeされたときをトリガーに設定した
- 実装変えた
- fix
- 実装直した
- baseをmainに直指定
- remove
- body追加
- remove
- permissionsを追加
- remove
- tokenを設定
- permissions追加
- envの位置変更
- gh_tokenに修正
